### PR TITLE
Add new simulator experiment runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,16 @@
 .vscode
 
 # Benchmarking simulator configuration files.
-/*.conf
-/*.csv
-/*.json
-/*.log
-/*.dot
+
+*.json
+*.dot
+*.csv
+*.log
+*.conf
+
 /*.png
 /*.pdf
+
 
 # Virtual environment.
 venv
@@ -36,3 +39,12 @@ traces/alibaba-cluster-trace-v2018/*.pkl
 
 # Cache
 .cache
+
+# Tetrisched files
+tetrisched_*.log
+libtetrisched_performance.csv
+tetrisched_*.dot
+
+# Stderr and Stdout files
+*.stderr
+*.stdout

--- a/scripts/simulator_experiment_runner/README.md
+++ b/scripts/simulator_experiment_runner/README.md
@@ -1,0 +1,8 @@
+# Simulator Experiment Runner Script
+
+
+## Config file format
+
+```yaml
+TODO
+```

--- a/scripts/simulator_experiment_runner/README.md
+++ b/scripts/simulator_experiment_runner/README.md
@@ -1,8 +1,136 @@
-# Simulator Experiment Runner Script
+# Simulator Experiment Runner
 
+## Overview
 
-## Config file format
+This script is designed to run scheduling experiments using the Erdos Scheduling Simulator. It reads a YAML configuration file, generates experiment combinations based on the provided matrix, and executes them in parallel.
+
+## Usage
+
+Run the script using Python:
+
+```bash
+python -m scripts.simulator_experiment_runner --config <path_to_config> --output-dir <path_to_output_dir> [--num-workers <num>] [--dry-run]
+```
+
+### Arguments
+
+- `--config`: Path to the YAML configuration file defining the experiment setup.
+- `--output-dir`: Path to the directory where results will be stored.
+- `--num-workers`: Number of parallel workers to run experiments (default: 5).
+- `--dry-run`: If specified, the script will print the experiment configurations without executing them.
+
+### Example Command
+
+```bash
+python -m scripts.simulator_experiment_runner --config sample_experiment.yaml --output-dir results --num-workers 10
+```
+
+### Configuration File
+
+The configuration file is a YAML file that defines the experiment setup. Below is an example configuration file:
 
 ```yaml
-TODO
+# Extracted experiment configuration from alibaba_plot.py
+
+# Base flags that apply to all experiments
+base_flags:
+    # Worker config
+    worker_profile_path: "profiles/workers/alibaba_cluster_final.yaml"
+
+    # Workload config
+    workload_profile_paths:
+        - "traces/alibaba-cluster-trace-v2018/easy_dag_sukrit_10k.pkl"
+        - "traces/alibaba-cluster-trace-v2018/medium_dag_sukrit_10k.pkl"
+        - "traces/alibaba-cluster-trace-v2018/hard_dag_sukrit_10k.pkl"
+    workload_profile_path_labels: ["easy", "medium", "hard"]
+
+    # Loader config
+    execution_mode: "replay"
+    replay_trace: "alibaba"
+    alibaba_loader_task_cpu_usage_random: true
+    alibaba_loader_task_cpu_multiplier: 1
+    alibaba_loader_task_cpu_usage_min: 120
+    alibaba_loader_task_cpu_usage_max: 1500
+    alibaba_loader_min_critical_path_runtimes: [200, 500, 600]
+    alibaba_loader_max_critical_path_runtimes: [500, 1000, 1000]
+
+    override_release_policies: ["poisson", "poisson", "poisson"]
+    randomize_start_time_max: 50
+    min_deadline: 5
+    max_deadline: 500
+    min_deadline_variances: [25, 50, 10]
+    max_deadline_variances: [50, 100, 25]
+    enforce_deadlines: true
+    random_seed: 420665456
+
+    # Scheduler runtime set to zero
+    scheduler_runtime: 0
+
+# Different schedulers to test
+schedulers:
+    - name: "DSched"
+      flags:
+          scheduler: "TetriSched"
+          release_taskgraphs: true
+          opt_passes:
+              [
+                  "CRITICAL_PATH_PASS",
+                  "CAPACITY_CONSTRAINT_PURGE_PASS",
+                  "DYNAMIC_DISCRETIZATION_PASS",
+              ]
+          retract_schedules: true
+          scheduler_max_occupancy_threshold: 0.999
+          finer_discretization_at_prev_solution: true
+          scheduler_reconsideration_period: 0.9
+          scheduler_time_discretization: 1
+          scheduler_max_time_discretization: 5
+          finer_discretization_window: 5
+          scheduler_plan_ahead_no_consideration_gap: 5
+          drop_skipped_tasks: true
+          scheduler_time_limit: 120
+
+# Matrix of parameters to vary across experiments
+matrix:
+    # Arrival rate pairs (medium, hard) - these are the key experimental parameters
+    # Each inner list represents arrival rates for [easy, medium, hard] workloads
+    override_poisson_arrival_rates:
+        - [0, 0.01, 0.0385]
+
+    # Number of invocations for [easy, medium, hard] workloads
+    override_num_invocations:
+        - [0, 1, 1]
+
+# Naming template for experiments
+naming: "{scheduler}+arrival={override_poisson_arrival_rates}+inv={override_num_invocations}"
+
+# Additonal metadata
+multi_enum_flags:
+    - opt_passes
 ```
+
+The only funky thing to keep in mind is multi enum flags (like `--opt-passes`). You will need to explicitly mark such flags as multi enum under the `multi_enum_flags` section.
+
+### Output
+
+The script generates a CSV file (`results.csv`) in the specified output directory, containing the results of all experiments. Each row corresponds to an experiment, including its configuration and results.
+
+### Dry Run Mode
+
+Use the `--dry-run` flag to preview the experiment configurations without executing them. This is useful for validating the setup before running the experiments.
+
+### Error Handling
+
+The script includes robust error handling:
+- If the output directory already exists, the user is prompted to delete it or abort the operation.
+- Invalid configurations or unexpected errors are logged with detailed traceback information.
+
+### Debugging
+
+In case of unexpected failures, the script starts a `pdb` debug session to help identify the root cause.
+
+### Notes
+
+- Ensure the YAML configuration file is properly formatted and includes all required fields.
+- The script supports multi-enum flags, allowing complex configurations for schedulers.
+
+For more details, refer to the script source code in `__main__.py`.

--- a/scripts/simulator_experiment_runner/__main__.py
+++ b/scripts/simulator_experiment_runner/__main__.py
@@ -1,0 +1,302 @@
+import argparse
+import itertools
+import concurrent.futures
+import shutil
+import traceback
+
+
+from pathlib import Path
+from typing import Dict, Any, List
+
+
+from scripts.raysearch import run_and_analyze
+
+
+import yaml
+import pandas as pd
+
+
+from tqdm import tqdm
+
+
+def parse_experiment_config(config_path: Path) -> Dict[str, Any]:
+    """Parse and validate experiment configuration from YAML file."""
+    with open(config_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    fields = set(data.keys())
+
+    # Validate fields
+    required_fields = {"base_flags", "schedulers", "matrix", "naming"}
+    optional_fields = {"multi_enum_flags"}
+    valid_fields = required_fields | optional_fields
+
+    # Check required fields
+    missing = required_fields - fields
+    if missing:
+        raise ValueError(f"Missing required fields: {missing}")
+
+    # Check for invalid fields
+    invalid = fields - valid_fields
+    if invalid:
+        raise ValueError(f"Invalid fields: {invalid}")
+
+    # Validate schedulers structure
+    if not isinstance(data["schedulers"], list) or not data["schedulers"]:
+        raise ValueError("'schedulers' must be a non-empty list")
+
+    for scheduler in data["schedulers"]:
+        if "name" not in scheduler or "flags" not in scheduler:
+            raise ValueError("Each scheduler must have 'name' and 'flags' fields")
+        if not isinstance(scheduler["flags"], dict):
+            raise ValueError("Scheduler 'flags' must be a dictionary")
+
+    # Validate base_flags structure
+    if not isinstance(data["base_flags"], dict):
+        raise ValueError("'base_flags' must be a dictionary")
+
+    # Validate matrix structure
+    if not isinstance(data["matrix"], dict):
+        raise ValueError("'matrix' must be a dictionary")
+
+    for key, values in data["matrix"].items():
+        if not isinstance(values, list):
+            raise ValueError(f"Matrix parameter '{key}' must be a list")
+        # Values can be either a simple list or list of lists
+        if values and isinstance(values[0], list):
+            # Nested list - each inner list is a set of values to use together
+            for inner_list in values:
+                if not isinstance(inner_list, list):
+                    raise ValueError(
+                        f"Matrix parameter '{key}' contains mixed list types"
+                    )
+
+    return data
+
+
+def generate_experiment_matrix(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Generate all experiment combinations from the configuration matrix."""
+    experiments = []
+
+    # Get matrix parameters and their values
+    matrix_params = config["matrix"]
+    param_names = list(matrix_params.keys())
+
+    # Extract multi-enum flags, if specified
+    multi_enum_flags = config.get("multi_enum_flags", [])
+
+    # Process parameter values - handle both simple lists and nested lists
+    param_value_sets = []
+    for param_name in param_names:
+        values = matrix_params[param_name]
+        if values and isinstance(values[0], list):
+            # Nested list - each inner list is a separate option
+            param_value_sets.append(values)
+        else:
+            # Simple list - wrap each value as a single-item list for consistency
+            param_value_sets.append([[v] for v in values])
+
+    def format_flag_value(flag_value: Any, delim=',') -> str:
+        if isinstance(flag_value, list):
+            # Join list values with comma
+            values_str = delim.join(map(str, flag_value))
+            return f"{values_str}"
+        else:
+            return f"{flag_value}"
+
+    def format_flag(flag_name: str, flag_value: Any) -> List[str]:
+        # Boolean flags
+        if (
+            (isinstance(flag_value, bool) and flag_value)
+            or flag_value is None
+            or flag_value == ""
+        ):
+            return [f"--{flag_name}"]
+
+        # Multi-enum flags, with a list values
+        #
+        # Consider the --opt_passes flag, specified in the YAML file as follows:
+        #
+        # opt_passes:
+        #   - CRITICAL_PATH_OPTIMIZATION
+        #   - DYNAMIC_DISCRETIZATION
+        #
+        # The flags must be formatted as
+        #
+        # ["--opt_passes=CRITICAL_PATH_OPTIMIZATION", "--opt_passes=DYNAMIC_DISCRETIZATION"]
+        #
+        # and not
+        #
+        # ["--opt_passes="CRITICAL_PATH_OPTIMIZATION,DYNAMIC_DISCRETIZATION"]
+        #
+        # because it --opt_passes is a multi-enum flag
+        elif flag_name in multi_enum_flags and isinstance(flag_value, list):
+            return [f"--{flag_name}={format_flag_value(v)}" for v in flag_value]
+
+        # All other variants
+        else:
+            return [f"--{flag_name}={format_flag_value(flag_value)}"]
+
+    # Generate all combinations of parameter sets
+    for param_set_combination in itertools.product(*param_value_sets):
+        # param_set_combination is a tuple of lists, e.g. ([0.01, 0.02, 0.05], [200, 500])
+
+        # Generate experiment for each scheduler with this parameter set combination
+        for scheduler in config["schedulers"]:
+            experiment = {
+                "name": None,  # Will be set after we have the param dict
+                "flags": [],
+            }
+
+            # Add base flags
+            for flag_name, flag_value in config["base_flags"].items():
+                experiment["flags"].extend(format_flag(flag_name, flag_value))
+
+            # Add scheduler-specific flags
+            for flag_name, flag_value in scheduler["flags"].items():
+                experiment["flags"].extend(format_flag(flag_name, flag_value))
+
+            # Add matrix parameter flags
+            param_dict = {}
+            for param_name, param_value in zip(param_names, param_set_combination):
+                experiment["flags"].extend(format_flag(param_name, param_value))
+                param_dict[param_name] = format_flag_value(param_value, delim='~')
+
+            # Set experiment name using the param_dict
+            name = config["naming"].format(
+                scheduler=scheduler["name"], **param_dict
+            )
+            if ',' in name:
+                raise ValueError(f"Invalid experiment name '{name}'. Must not contain ','")
+            experiment["name"] = name
+
+            experiments.append(experiment)
+
+    return experiments
+
+
+def run_job(experiment: Dict[str, Any], output_dir: Path):
+    try:
+        result = run_and_analyze(
+            label=experiment['name'],
+            output_dir=output_dir,
+            flags=experiment['flags'],
+        )
+        return {
+            'experiment': experiment,
+            'result': result,
+        }
+    except Exception as e:
+        print(f"Failed to run {experiment}")
+        print("Exception:", e)
+        print(traceback.format_exc())
+        return {
+            'experiment': experiment,
+            'error': {
+                'traceback': traceback.format_exc(),
+            },
+        }
+
+
+class InvalidOutputDirectoryException(Exception):
+    pass
+
+
+def prepare_output_directory(output_dir: Path):
+    if output_dir.exists():
+        while True:
+            user_input = input(f"'{output_dir.resolve()}' already exists. Do you want to delete it? (y/n): ").lower().strip()
+
+            if user_input == 'y':
+                shutil.rmtree(output_dir)
+                print(f"Directory '{output_dir}' has been deleted.")
+                break
+            elif user_input == 'n':
+                raise InvalidOutputDirectoryException(f"Output directory already exists")
+            else:
+                print("Please enter 'y' for yes or 'n' for no.")
+
+    output_dir.mkdir(parents=True)
+
+
+def run_experiment(experiment: List[Dict[str, Any]], output_dir: Path, num_workers: int):
+    def task(job):
+        return run_job(job, output_dir)
+
+    prepare_output_directory(output_dir)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+        results = list(
+            tqdm(executor.map(task, experiment), total=len(experiment))
+        )
+
+    df = pd.json_normalize(results)
+    with open(output_dir / 'results.csv', 'w') as f:
+        df.to_csv(f, index=False)
+
+    print(df)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser("Helper script to spawn simulator experiments")
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to experiment configuration YAML file",
+    )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=5,
+        help="Number of parallel workers to run experiments.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Dry run mode that prints experiment configurations that will be spawned.",
+    )
+    parser.add_argument("--output-dir", type=Path, help="Path to output directory")
+
+    args = parser.parse_args()
+    if not args.dry_run:
+        if not args.config or not args.output_dir:
+            parser.error(
+                "--config and --output-dir are required when not using --dry-run"
+            )
+
+    config = parse_experiment_config(Path(args.config))
+    experiment = generate_experiment_matrix(config)
+
+    if args.dry_run:
+        print("DRY RUN - Printing experiment configurations without running them")
+        print(f"Config: {args.config}")
+        print(f"Total jobs to run: {len(experiment)}\n")
+
+        for i, job in enumerate(experiment, 1):
+            print(f"Job {i}: {job['name']}")
+            print(f"  Flags:")
+            for flag in job["flags"]:
+                print(f"    {flag}")
+            print()
+
+        return
+
+    print(f"Running experiment config '{args.config}' ({len(experiment)} jobs with {args.num_workers} workers).")
+    print(f"Dumping output to '{args.output_dir.resolve()}'")
+
+    try:
+        run_experiment(experiment, args.output_dir, args.num_workers)
+        print(f"Successfully ran experiment. Results are available at '{args.output_dir.resolve()}'")
+    except InvalidOutputDirectoryException as e:
+        print(f"Failed to run experiment. Reason: {e}")
+    except Exception as e:
+        print(f"Unexpectedly failed to run experiment. Reason: {e}")
+        print("Starting a pdb debug session to help root cause")
+        breakpoint()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simulator_experiment_runner/__main__.py
+++ b/scripts/simulator_experiment_runner/__main__.py
@@ -96,7 +96,7 @@ def generate_experiment_matrix(config: Dict[str, Any]) -> List[Dict[str, Any]]:
             # Simple list - wrap each value as a single-item list for consistency
             param_value_sets.append([[v] for v in values])
 
-    def format_flag_value(flag_value: Any, delim=',') -> str:
+    def format_flag_value(flag_value: Any, delim=",") -> str:
         if isinstance(flag_value, list):
             # Join list values with comma
             values_str = delim.join(map(str, flag_value))
@@ -160,14 +160,14 @@ def generate_experiment_matrix(config: Dict[str, Any]) -> List[Dict[str, Any]]:
             param_dict = {}
             for param_name, param_value in zip(param_names, param_set_combination):
                 experiment["flags"].extend(format_flag(param_name, param_value))
-                param_dict[param_name] = format_flag_value(param_value, delim='~')
+                param_dict[param_name] = format_flag_value(param_value, delim="~")
 
             # Set experiment name using the param_dict
-            name = config["naming"].format(
-                scheduler=scheduler["name"], **param_dict
-            )
-            if ',' in name:
-                raise ValueError(f"Invalid experiment name '{name}'. Must not contain ','")
+            name = config["naming"].format(scheduler=scheduler["name"], **param_dict)
+            if "," in name:
+                raise ValueError(
+                    f"Invalid experiment name '{name}'. Must not contain ','"
+                )
             experiment["name"] = name
 
             experiments.append(experiment)
@@ -178,22 +178,22 @@ def generate_experiment_matrix(config: Dict[str, Any]) -> List[Dict[str, Any]]:
 def run_job(experiment: Dict[str, Any], output_dir: Path):
     try:
         result = run_and_analyze(
-            label=experiment['name'],
+            label=experiment["name"],
             output_dir=output_dir,
-            flags=experiment['flags'],
+            flags=experiment["flags"],
         )
         return {
-            'experiment': experiment,
-            'result': result,
+            "experiment": experiment,
+            "result": result,
         }
     except Exception as e:
         print(f"Failed to run {experiment}")
         print("Exception:", e)
         print(traceback.format_exc())
         return {
-            'experiment': experiment,
-            'error': {
-                'traceback': traceback.format_exc(),
+            "experiment": experiment,
+            "error": {
+                "traceback": traceback.format_exc(),
             },
         }
 
@@ -205,33 +205,41 @@ class InvalidOutputDirectoryException(Exception):
 def prepare_output_directory(output_dir: Path):
     if output_dir.exists():
         while True:
-            user_input = input(f"'{output_dir.resolve()}' already exists. Do you want to delete it? (y/n): ").lower().strip()
+            user_input = (
+                input(
+                    f"'{output_dir.resolve()}' already exists. Do you want to delete it? (y/n): "
+                )
+                .lower()
+                .strip()
+            )
 
-            if user_input == 'y':
+            if user_input == "y":
                 shutil.rmtree(output_dir)
                 print(f"Directory '{output_dir}' has been deleted.")
                 break
-            elif user_input == 'n':
-                raise InvalidOutputDirectoryException(f"Output directory already exists")
+            elif user_input == "n":
+                raise InvalidOutputDirectoryException(
+                    f"Output directory already exists"
+                )
             else:
                 print("Please enter 'y' for yes or 'n' for no.")
 
     output_dir.mkdir(parents=True)
 
 
-def run_experiment(experiment: List[Dict[str, Any]], output_dir: Path, num_workers: int):
+def run_experiment(
+    experiment: List[Dict[str, Any]], output_dir: Path, num_workers: int
+):
     def task(job):
         return run_job(job, output_dir)
 
     prepare_output_directory(output_dir)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
-        results = list(
-            tqdm(executor.map(task, experiment), total=len(experiment))
-        )
+        results = list(tqdm(executor.map(task, experiment), total=len(experiment)))
 
     df = pd.json_normalize(results)
-    with open(output_dir / 'results.csv', 'w') as f:
+    with open(output_dir / "results.csv", "w") as f:
         df.to_csv(f, index=False)
 
     print(df)
@@ -284,12 +292,16 @@ def main():
 
         return
 
-    print(f"Running experiment config '{args.config}' ({len(experiment)} jobs with {args.num_workers} workers).")
+    print(
+        f"Running experiment config '{args.config}' ({len(experiment)} jobs with {args.num_workers} workers)."
+    )
     print(f"Dumping output to '{args.output_dir.resolve()}'")
 
     try:
         run_experiment(experiment, args.output_dir, args.num_workers)
-        print(f"Successfully ran experiment. Results are available at '{args.output_dir.resolve()}'")
+        print(
+            f"Successfully ran experiment. Results are available at '{args.output_dir.resolve()}'"
+        )
     except InvalidOutputDirectoryException as e:
         print(f"Failed to run experiment. Reason: {e}")
     except Exception as e:


### PR DESCRIPTION
Helper script to spawn simulator experiments.

It uses a YAML config file format to specify matrices of experiments.

- [x] Document YAML format in the README
- [x] Include an example config file


In a future PR, I will patch in support for running partial matrices. It will include a utility to split an experiment run into several subcommands that can be run on separate machines.